### PR TITLE
feat: Add navigation menu

### DIFF
--- a/2025/README.md
+++ b/2025/README.md
@@ -1,6 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by [Maxime Dufour](https://www.maximedufour.com/)*
-
 # DisCoTec 2025 - 20th International Federated Conference on Distributed Computing Techniques
 
 Welcome to DisCoTec 2025! 

--- a/2025/accepted-papers.md
+++ b/2025/accepted-papers.md
@@ -1,7 +1,3 @@
-
-[![](banner2025.png)](.)
-*Photo by *
-
 # Accepted papers
 ## [COORDINATION](coordination)
 

--- a/2025/accepted-papers.md
+++ b/2025/accepted-papers.md
@@ -1,3 +1,8 @@
+---
+title: Accepted papers
+menu_show: true
+---
+
 # Accepted papers
 ## [COORDINATION](coordination)
 

--- a/2025/accepted-papers.md
+++ b/2025/accepted-papers.md
@@ -1,6 +1,7 @@
 ---
 title: Accepted papers
 menu_show: true
+order: 1
 ---
 
 # Accepted papers

--- a/2025/coordination.md
+++ b/2025/coordination.md
@@ -1,7 +1,3 @@
-[![](banner2024.v2.png)](.)
-*Photo by Robin Mathlener on [Unsplash](https://unsplash.com/photos/black-concrete-building-during-night-time-3x-fuFPs-G0)*  
-
-
 # COORDINATION 2024 - 26th International Conference on Coordination Models and Languages
 
 COORDINATION 2024 is one of the three conferences of [DisCoTec 2024](.).

--- a/2025/csep.md
+++ b/2025/csep.md
@@ -1,5 +1,3 @@
-[![](banner2024.v2.png)](.)
-
 # Call for Satellite Events (Workshops / Tutorials)
 
 DisCoTec is one of the major events sponsored by the International Federation for Information Processing (IFIP) and the European Association for Programming Languages and Systems (EAPLS).

--- a/2025/dais.md
+++ b/2025/dais.md
@@ -1,7 +1,3 @@
-[![](banner2024.v2.png)](.)
-*Photo by Robin Mathlener on [Unsplash](https://unsplash.com/photos/black-concrete-building-during-night-time-3x-fuFPs-G0)* 
-
-
 # DAIS 2024 - 24th International Conference on Distributed Applications and Interoperable Systems
 
 DAIS 2024 is one of the three conferences of [DisCoTec 2024](.).

--- a/2025/dais_ae.md
+++ b/2025/dais_ae.md
@@ -1,6 +1,3 @@
-[![](banner2024.v2.png)](.)
-*Photo by Robin Mathlener on [Unsplash](https://unsplash.com/photos/black-concrete-building-during-night-time-3x-fuFPs-G0)*
-
 # Artefact Evaluation
 [DAIS](https://www.discotec.org/2024/dais) this year includes an artefact evaluation performed by the artefact evaluation committee (AEC). The goal of the artefact evaluation is to enable future researchers to more effectively build on and compare with previous work. The Artefact Evaluation Committee (AEC) will review the artefact. We will be attributing 3 badges, according to [EAPLS guidelines](https://eapls.org/pages/artifact_badges/):
 1.	Artefact **functional**: documented, consistent, complete, exercisable;

--- a/2025/forte.md
+++ b/2025/forte.md
@@ -1,7 +1,3 @@
-[![](banner2024.v2.png)](.)
-*Photo by Robin Mathlener on [Unsplash](https://unsplash.com/photos/black-concrete-building-during-night-time-3x-fuFPs-G0)*  
-
-
 # FORTE 2024 - 44th International Conference on Formal Techniques for Distributed Objects, Components, and Systems
 
 FORTE 2024 is one of the three conferences of [DisCoTec 2024](.), the 19th International Federated Conference on Distributed Computing Techniques.

--- a/2025/forte_ae.md
+++ b/2025/forte_ae.md
@@ -1,6 +1,3 @@
-[![](banner2024.v2.png)](.)
-*Photo by Robin Mathlener on [Unsplash](https://unsplash.com/photos/black-concrete-building-during-night-time-3x-fuFPs-G0)*
-
 # Artefact Evaluation
 [FORTE](https://www.discotec.org/2024/forte) this year includes an artefact evaluation performed by the artefact evaluation committee (AEC). The goal of the artefact evaluation is to enable future researchers to more effectively build on and compare with previous work. The Artefact Evaluation Committee (AEC) will review the artefact. We will be attributing 3 badges, according to [EAPLS guidelines](https://eapls.org/pages/artifact_badges/):
 1.	Artefact **functional**: documented, consistent, complete, exercisable;

--- a/2025/hotels.md
+++ b/2025/hotels.md
@@ -1,6 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by *
-
 # Hotels in Lille
 
 

--- a/2025/ice.md
+++ b/2025/ice.md
@@ -1,6 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by [Maxime Dufour](https://www.maximedufour.com/)*
-
 # ICE 2025 - 18th Interaction and Concurrency Experience
 
 Interaction and Concurrency Experiences (ICE) is a series of international scientific meetings oriented to theoretical computer science researchers with special interest in models, verification, tools, and programming primitives for concurrent systems and complex interactions. 

--- a/2025/invited.md
+++ b/2025/invited.md
@@ -1,6 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by *
-
 # Invited Speakers
 
 TBA

--- a/2025/programme.md
+++ b/2025/programme.md
@@ -1,6 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by * 
-
 # Programme
 
 TBA

--- a/2025/programme.md
+++ b/2025/programme.md
@@ -1,6 +1,7 @@
 ---
 title: Programme
 menu_show: true
+order: 0
 ---
 
 # Programme

--- a/2025/programme.md
+++ b/2025/programme.md
@@ -1,3 +1,8 @@
+---
+title: Programme
+menu_show: true
+---
+
 # Programme
 
 TBA

--- a/2025/registration.md
+++ b/2025/registration.md
@@ -1,3 +1,8 @@
+---
+title: Registration
+menu_show: true
+---
+
 ## Important Dates
 TBA
 

--- a/2025/registration.md
+++ b/2025/registration.md
@@ -1,6 +1,7 @@
 ---
 title: Registration
 menu_show: true
+order: 2
 ---
 
 ## Important Dates

--- a/2025/registration.md
+++ b/2025/registration.md
@@ -1,7 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by *
-
-
 ## Important Dates
 TBA
 

--- a/2025/tutorials.md
+++ b/2025/tutorials.md
@@ -1,3 +1,8 @@
+---
+title: Tutorials
+menu_show: true
+---
+
 # Tutorials
 The DisCoTec Tutorials focus on emerging topics and aspects of the distributed computing field, ranging from new practical techniques and technologies to lessons learnt from projects and industry experiences.
 The pre-conference tutorials will take place on Monday, June 19, 2023, and post-conference tutorials on Friday, June 23, 2023.

--- a/2025/tutorials.md
+++ b/2025/tutorials.md
@@ -1,6 +1,7 @@
 ---
 title: Tutorials
 menu_show: true
+order: 4
 ---
 
 # Tutorials

--- a/2025/tutorials.md
+++ b/2025/tutorials.md
@@ -1,5 +1,3 @@
-[![](discotec2023-banner.v3.png)](https://www.discotec.org/2023/)
-
 # Tutorials
 The DisCoTec Tutorials focus on emerging topics and aspects of the distributed computing field, ranging from new practical techniques and technologies to lessons learnt from projects and industry experiences.
 The pre-conference tutorials will take place on Monday, June 19, 2023, and post-conference tutorials on Friday, June 23, 2023.

--- a/2025/venue.md
+++ b/2025/venue.md
@@ -1,6 +1,7 @@
 ---
 title: Venue
 menu_show: true
+order: 3
 ---
 
 # Venue: Lille, France

--- a/2025/venue.md
+++ b/2025/venue.md
@@ -1,7 +1,3 @@
-[![](banner2025.png)](.)
-*Photo by *
-
-
 # Venue: Lille, France
 
 ## Quick Links

--- a/2025/venue.md
+++ b/2025/venue.md
@@ -1,3 +1,8 @@
+---
+title: Venue
+menu_show: true
+---
+
 # Venue: Lille, France
 
 ## Quick Links

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,41 @@
+<!-- Display banner in template for 2025 pages -->
+{% if page.url contains '/2025/' %}
+{% assign display_banner = "yes" %}
+{% else %}
+{% assign display_banner = "no" %}
+{% endif %}
+
+{% if display_banner == "yes" %}
+<p class="banner">
+    <a href=".">
+        <img src="/2025/banner2025.png" alt="">
+    </a>
+    <em class="banner-credit">
+        Photo by
+        <a href="https://www.maximedufour.com/">
+            Maxime Dufour
+        </a>
+    </em>
+</p>
+
+<nav class="site-nav">
+    <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+    <label for="nav-trigger">
+        <span class="menu-icon">
+        <svg viewBox="0 0 18 15" width="18px" height="15px">
+            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+        </svg>
+        </span>
+    </label>
+
+    <a class="site-title" rel="author" href=".">DisCoTec 2025</a>
+    <div class="trigger">
+        {% assign pages_list = site.pages | sort: "order" %}
+        {% for my_page in pages_list %}
+        {% if my_page.menu_show == true %}
+            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+        {% endif %}
+        {% endfor %}
+    </div>
+</nav>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,9 +28,29 @@
       {% endif %}
 
       {% if display_banner == "yes" %}
-      <p><a href="."><img src="/2025/banner2025.png" alt=""></a>
-        <em>Photo by <a href="https://www.maximedufour.com/">Maxime Dufour</a></em>
+      <p class="banner"><a href="."><img src="/2025/banner2025.png" alt=""></a>
+        <em class="banner-credit">Photo by <a href="https://www.maximedufour.com/">Maxime Dufour</a></em>
       </p>
+
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {% assign pages_list = site.pages %}
+          {% for my_page in pages_list %}
+            {% if my_page.menu_show == true %}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {% endif %}
+          {% endfor %}
+        </div>
+      </nav>
       {% endif %}
       <!---->
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,6 +43,7 @@
         </label>
 
         <div class="trigger">
+          <a class="site-title" rel="author" href=".">DisCoTec 2025</a>
           {% assign pages_list = site.pages %}
           {% for my_page in pages_list %}
             {% if my_page.menu_show == true %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,6 +20,20 @@
       <!-- <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1> -->
       {% endif %}
 
+      <!-- Display banner in template for 2025 pages -->
+      {% if page.url contains '/2025/' %}
+      {% assign display_banner = "yes" %}
+      {% else %}
+      {% assign display_banner = "no" %}
+      {% endif %}
+
+      {% if display_banner == "yes" %}
+      <p><a href="."><img src="/2025/banner2025.png" alt=""></a>
+        <em>Photo by <a href="https://www.maximedufour.com/">Maxime Dufour</a></em>
+      </p>
+      {% endif %}
+      <!---->
+
       {{ content }}
 
       {% if site.github.private != true and site.github.license %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,7 +44,7 @@
 
         <a class="site-title" rel="author" href=".">DisCoTec 2025</a>
         <div class="trigger">
-          {% assign pages_list = site.pages %}
+          {% assign pages_list = site.pages | sort: "order" %}
           {% for my_page in pages_list %}
             {% if my_page.menu_show == true %}
               <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,40 +20,7 @@
       <!-- <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1> -->
       {% endif %}
 
-      <!-- Display banner in template for 2025 pages -->
-      {% if page.url contains '/2025/' %}
-      {% assign display_banner = "yes" %}
-      {% else %}
-      {% assign display_banner = "no" %}
-      {% endif %}
-
-      {% if display_banner == "yes" %}
-      <p class="banner"><a href="."><img src="/2025/banner2025.png" alt=""></a>
-        <em class="banner-credit">Photo by <a href="https://www.maximedufour.com/">Maxime Dufour</a></em>
-      </p>
-
-      <nav class="site-nav">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger">
-          <span class="menu-icon">
-            <svg viewBox="0 0 18 15" width="18px" height="15px">
-              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
-            </svg>
-          </span>
-        </label>
-
-        <a class="site-title" rel="author" href=".">DisCoTec 2025</a>
-        <div class="trigger">
-          {% assign pages_list = site.pages | sort: "order" %}
-          {% for my_page in pages_list %}
-            {% if my_page.menu_show == true %}
-              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-            {% endif %}
-          {% endfor %}
-        </div>
-      </nav>
-      {% endif %}
-      <!---->
+      {% include header.html %}
 
       {{ content }}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,8 +42,8 @@
           </span>
         </label>
 
+        <a class="site-title" rel="author" href=".">DisCoTec 2025</a>
         <div class="trigger">
-          <a class="site-title" rel="author" href=".">DisCoTec 2025</a>
           {% assign pages_list = site.pages %}
           {% for my_page in pages_list %}
             {% if my_page.menu_show == true %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -77,7 +77,10 @@ $spacing-unit:     30px !default;
     }
 
     .trigger {
-      display: inline;
+      width: 82%;
+      display: inline-flex;
+      justify-content: space-evenly;
+      flex-direction: row;
     }
   
     .menu-icon {
@@ -146,6 +149,7 @@ $spacing-unit:     30px !default;
       input:checked ~ .trigger {
         display: block;
         padding-bottom: 5px;
+        width: auto;
       }
   
       .page-link {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -161,6 +161,10 @@ $spacing-unit:     30px !default;
         }
         margin-left: 20px;
       }
+
+      label {
+        margin: 0;
+      }
     }
   }
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -188,7 +188,7 @@ $spacing-unit:     $spacer-5;
   bottom: 10px;
   left: 14px;
   color: $text-white;
-  background: $bg-gray-dark;
+  background: #2b2727b0;
   padding: 6px 10px;
   border-radius: 12px;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -30,6 +30,37 @@ $spacing-unit:     30px !default;
     }
   }
 
+@mixin relative-font-size($ratio) {
+  font-size: $base-font-size * $ratio;
+}
+
+.site-title {
+  @include relative-font-size(1.3);
+  line-height: $base-line-height * $base-font-size * 2.25;
+  letter-spacing: 0px;
+  margin-bottom: 0;
+  float: left;
+  padding-right:32px;
+
+  font-family: "Roboto", sans-serif;
+  font-weight: 300;
+  font-style: normal;
+
+  &,
+  &:visited {
+      color: $grey-color-dark;
+  }
+
+  &:hover {
+    text-decoration: none;
+    color: #435ed3;
+  }
+
+  @include media-query($on-palm) {
+    display: none;
+  }
+}
+
 /**
 * Site navigation bar
 */

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,22 +4,22 @@
 @import "{{ site.theme }}";
 
 /**
-* Imported from minima theme: https://github.com/sefm-conference/2024/tree/main/_sass
+* Use jekyll-theme-primer defaults (https://github.com/pages-themes/primer/blob/v0.6.0/_sass/primer-support/lib/variables/colors.scss and others).
 **/
 
-$base-line-height: 1.5 !default;
-$base-font-size:   16px !default;
-$text-color:       #111 !default;
-$background-color: #fdfdfd !default;
+$base-line-height: $body-line-height;
+$base-font-size:   $body-font-size;
+$text-color:       $text-gray-dark;
+$background-color: $bg-white;
 
-$grey-color:       #828282 !default;
-$grey-color-light: lighten($grey-color, 40%) !default;
-$grey-color-dark:  darken($grey-color, 25%) !default;
+$grey-color:       $text-gray;
+$grey-color-light: $text-gray-light;
+$grey-color-dark:  $text-gray-dark;
 
-$on-palm:          750px !default;
-$on-laptop:        1200px !default;
+$on-palm:          $width-md !default;
+$on-laptop:        $width-xl !default;
 
-$spacing-unit:     30px !default;
+$spacing-unit:     $spacer-5;
 
 // Use media queries like this:
 // @include media-query($on-palm) {
@@ -44,10 +44,10 @@ $spacing-unit:     30px !default;
   letter-spacing: 0px;
   margin-bottom: 0;
   float: left;
-  padding-right:32px;
+  padding-right:$spacer-5;
 
-  font-family: "Roboto", sans-serif;
-  font-weight: 300;
+  font-family: $body-font;
+  font-weight: $font-weight-light;
   font-style: normal;
 
   &,
@@ -57,7 +57,7 @@ $spacing-unit:     30px !default;
 
   &:hover {
     text-decoration: none;
-    color: #435ed3;
+    color: $text-blue;
   }
 
   @include media-query($on-palm) {
@@ -74,8 +74,10 @@ $spacing-unit:     30px !default;
 
     position: sticky;
     top: 0;
-    border-bottom: 1px solid #d9dbdd;
-    background: white;
+    border-bottom-width: $border-width;
+    border-bottom-style: $border-style;
+    border-bottom-color: $border-color;
+    background: $bg-white;
   
     .nav-trigger {
         display: none;
@@ -101,7 +103,7 @@ $spacing-unit:     30px !default;
   
       // Gaps between nav items, but not on the last one
       &:not(:last-child) {
-        margin-right: 31px;
+        margin-right: $spacer-5;
       }
     }
 
@@ -185,8 +187,8 @@ $spacing-unit:     30px !default;
   position: absolute;
   bottom: 10px;
   left: 14px;
-  color: white;
-  background: #2b2727b0;
+  color: $text-white;
+  background: $bg-gray-dark;
   padding: 6px 10px;
   border-radius: 12px;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -46,8 +46,8 @@ $spacing-unit:     $spacer-5;
   float: left;
   padding-right:$spacer-5;
 
-  font-family: $body-font;
-  font-weight: $font-weight-light;
+  font-family: "Roboto", sans-serif;
+  font-weight: $font-weight-bold;
   font-style: normal;
 
   &,

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,144 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+$base-line-height: 1.5 !default;
+$base-font-size:   16px !default;
+$text-color:       #111 !default;
+$background-color: #fdfdfd !default;
+
+$grey-color:       #828282 !default;
+$grey-color-light: lighten($grey-color, 40%) !default;
+$grey-color-dark:  darken($grey-color, 25%) !default;
+
+$on-palm:          750px !default;
+$on-laptop:        1200px !default;
+
+$spacing-unit:     30px !default;
+
+// Use media queries like this:
+// @include media-query($on-palm) {
+//   .wrapper {
+//     padding-right: $spacing-unit / 2;
+//     padding-left: $spacing-unit / 2;
+//   }
+// }
+@mixin media-query($device) {
+    @media screen and (max-width: $device) {
+      @content;
+    }
+  }
+
+/**
+* Site navigation bar
+*/
+.site-nav {
+    float: center;
+    line-height: $base-line-height * $base-font-size * 2.25;
+  
+    .nav-trigger {
+        display: none;
+    }
+
+    .trigger {
+      display: inline;
+    }
+  
+    .menu-icon {
+      display: none;
+    }
+  
+    .page-link {
+      color: $text-color;
+      line-height: $base-line-height;
+      display: inline-block;
+      background: none;
+      border: none;
+  
+      // Gaps between nav items, but not on the last one
+      &:not(:last-child) {
+        margin-right: 31px;
+      }
+    }
+
+    .page-link:hover {
+      background: inherit;
+      border: inherit;
+    }
+
+    .page-link:focus {
+      box-shadow: none;
+    }
+  
+    @include media-query($on-palm) {
+      position: absolute;
+      top: 9px;
+      right: $spacing-unit / 2;
+      background-color: $background-color;
+      border: 1px solid $grey-color-light;
+      border-radius: 5px;
+      text-align: right;
+  
+      label[for="nav-trigger"] {
+        display: block;
+        float: right;
+        width: 36px;
+        height: 36px;
+        z-index: 2;
+        cursor: pointer;
+      }
+  
+      .menu-icon {
+        display: block;
+        float: right;
+        width: 36px;
+        height: 26px;
+        line-height: 0;
+        padding-top: 10px;
+        text-align: center;
+  
+        > svg {
+          fill: $grey-color-dark;
+        }
+      }
+  
+      input ~ .trigger {
+        clear: both;
+        display: none;
+      }
+  
+      input:checked ~ .trigger {
+        display: block;
+        padding-bottom: 5px;
+      }
+  
+      .page-link {
+        display: block;
+        padding: 5px 10px;
+  
+        &:not(:last-child) {
+          margin-right: 0;
+        }
+        margin-left: 20px;
+      }
+    }
+  }
+
+/**
+* Site banner
+*/
+.banner {
+  position: relative;
+  margin: 0 !important;
+}
+
+.banner-credit {
+  position: absolute;
+  bottom: 10px;
+  left: 14px;
+  color: white;
+  background: #2b2727b0;
+  padding: 6px 10px;
+  border-radius: 12px;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -71,6 +71,11 @@ $spacing-unit:     30px !default;
 .site-nav {
     float: center;
     line-height: $base-line-height * $base-font-size * 2.25;
+
+    position: sticky;
+    top: 0;
+    border-bottom: 1px solid #d9dbdd;
+    background: white;
   
     .nav-trigger {
         display: none;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -3,6 +3,10 @@
 
 @import "{{ site.theme }}";
 
+/**
+* Imported from minima theme: https://github.com/sefm-conference/2024/tree/main/_sass
+**/
+
 $base-line-height: 1.5 !default;
 $base-font-size:   16px !default;
 $text-color:       #111 !default;


### PR DESCRIPTION
For next year, @sbliudze (general chair) wants a navigation menu [just like SEFM 2024 does](https://sefm-conference.github.io/2024/callforpapers/); this thus imports navigation component and related style from [minima theme](https://github.com/sefm-conference/2024/tree/main/_sass).

* For the `2025` subsite, I removed the banner image from each page file (no more duplication), and put it in a `header.html` template file;
* This template file is only included for `/2025` pages (= other websites should not be impacted by this PR);
* To be included in the navigation bar, a page must include the following header:
```text
---
title: Accepted papers
menu_show: true
order: 1
---
```

I also slightly modified the menu to always appear on screen, no matter the scroll level.

#### Screenshots

##### Before

![image](https://github.com/user-attachments/assets/b173925a-47d5-43fe-bdd6-a8b92fc756d8)

##### After

![image](https://github.com/user-attachments/assets/bcd6bd7c-9077-4e95-82d6-91d5fafdbcb7)
